### PR TITLE
Ster veen patch 1

### DIFF
--- a/pyautoplot/main.py
+++ b/pyautoplot/main.py
@@ -714,13 +714,13 @@ def collect_stats_ms(msname, max_mem_bytes=4*(2**30), first_timeslot=0, max_time
         pass
     
 
-    num_ts = min(max_ts, max(0,num_timeslots-first_timeslot))
+    num_ts = int64(min(max_ts, max(0,num_timeslots-first_timeslot)))
     data_shape  = (num_ant, num_ant, num_pol, num_ts, num_chan)
     data = ma.array(zeros(data_shape, dtype=complex64),
                     mask=zeros(data_shape, dtype=bool))
 
     ms_table = tables.table(ms.msname)
-    nrows = min(ms_table.nrows(), num_bl*num_ts)
+    nrows = int64(min(ms_table.nrows(), num_bl*num_ts))
     rows      = ms_table[0:nrows]
     xx,xy,yx,yy = 0,1,2,3
     printnow('reading data')
@@ -878,7 +878,7 @@ def inspect_ms(msname, ms_id, max_mem_bytes=4*(2**30), root=os.path.expanduser('
     # write_plot('Rate', lambda x:log10(abs(x)), vmin=-4, vmax=0.0, cmap=cmap)
 
     results_name=os.path.join(output_dir,msname.split('/')[-1][:-3]+'-data.pickle')
-    pickle.dump(results, open(results_name, mode='w'), protocol=pickle.HIGHEST_PROTOCOL)
+    pickle.dump(results, open(results_name, mode='wb'), protocol=pickle.HIGHEST_PROTOCOL)
 
     ms = MeasurementSetSummary(msname)
     time_slots, vis_cube = collect_timeseries_ms(ms, num_points=240)

--- a/pyautoplot/main.py
+++ b/pyautoplot/main.py
@@ -24,6 +24,8 @@ from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.backend_bases import FigureCanvasBase
 
+from functools import reduce
+
 try:
     import pyautoplot.ma      as ma
     import pyautoplot.forkmap as forkmap

--- a/pyautoplot/utilities.py
+++ b/pyautoplot/utilities.py
@@ -41,7 +41,7 @@ def map_casa_table(function, casa_table, column_name='DATA', flag_name='FLAG', c
     selection = selection.selectrows(arange(0, nrows, rowincr))
     nrows = selection.nrows()
     lastset = nrows % chunksize
-    complete_chunks = nrows / chunksize
+    complete_chunks = int(nrows / chunksize)
     results = []
     for chunk in range(complete_chunks):
         if max_chunks:


### PR DESCRIPTION
To run the code in python 3 required some patches. 

Python 3 creates floats when dividing two integers. This may cause problems at other parts of the code.
The shape also required integeres.
Opening binary files require open(name, 'wb')

With these fixes I could run it on the headnode. But the code is currently broken in production.